### PR TITLE
Lucky Wind Separation Update

### DIFF
--- a/Battle.rb
+++ b/Battle.rb
@@ -450,7 +450,7 @@ class PokeBattle_Battle
     # Gen 9 Mod - Rage Fist variable array
     @rageFist        = [Array.new(p1.length, 0), Array.new(p2.length, 0)]
     @rageFistSOS     = 0
-    
+
     #Kaizomod
     @keepPrimalWeather = false
     for i in 0...4
@@ -1504,7 +1504,7 @@ class PokeBattle_Battle
         pri += 1 if @choices[i][2].basedamage != 0 && @battlers[i].crested == :FERALIGATR && @battlers[i].turncount == 1 # Feraligatr Crest
         pri += 3 if @battlers[i].ability == :TRIAGE && PBStuff::HEALFUNCTIONS.include?(@choices[i][2].function)
         pri = -2 if @battlers[i].ability == :MYCELIUMMIGHT && @choices[i][2].basedamage == 0 && @battlers[i].effects[:TwoTurnAttack] == 0 # Is status move # Gen 9 Mod - Added Mycelium Might
-        
+
         # Updating Giga Move priority here (on turn of evolution)
         # pri -= 6 if @battlers[i].species == :CORVIKNIGHT && @battlers[i].giga && @choices[i][2].move == :BRAVEBIRD
       end
@@ -2454,7 +2454,7 @@ class PokeBattle_Battle
 
     # @SWu add the specific GMax stone here
     pbDisplay(_INTL("{1} is reacting to its giga core!", @battlers[index].pbThis))
-  
+
     # Animation
     pbCommonAnimation("MegaEvolution",@battlers[index],nil)
 
@@ -2485,7 +2485,7 @@ class PokeBattle_Battle
 
       newmove=PBMove.new(PBStuff::POKEMONTOGIGAMOVE[@battlers[index].species][0])
       @battlers[index].moves[i]=PokeBattle_Move.pbFromPBMove(@battle,newmove,@battlers[index])
-      
+
       if !(@battlers[index].zmoves.nil? || @battlers[index].item == :INTERCEPTZ)
         @battle.updateZMoveIndexBattler(i,@battlers[index])
       end
@@ -2505,7 +2505,7 @@ class PokeBattle_Battle
     # Re-update ability of giga-evolved mon
     @battlers[index].pokemon.ability = @battlers[index].backupability
     @battlers[index].giga = true
-    
+
     # @battlers[index].pbAbilitiesOnSwitchIn(true)
   end
 
@@ -3394,7 +3394,7 @@ class PokeBattle_Battle
         if pkmn.ability != :MAGICGUARD && !(pkmn.ability == :WONDERGUARD && @battle.FE == :COLOSSEUM) && !pkmn.hasWorkingItem(:HEAVYDUTYBOOTS)
           atype = :FIRE
           atype = :ROCK if @field.effect == :ICY || @field.effect == :FROZENDIMENSION || @field.effect == :SNOWYMOUNTAIN || @field.effect == :UNDERWATER
-          
+
           eff = PBTypes.twoTypeEff(atype, pkmn.type1, pkmn.type2)
           if ($game_switches[:Inversemode] && !@battle.isOnline?) ^ (@field.effect == :INVERSE)
             switcheff = { 16 => 1, 8 => 2, 4 => 4, 2 => 8, 1 => 16, 0 => 16 }
@@ -5609,7 +5609,7 @@ class PokeBattle_Battle
         hpgain=i.pbRecoverHP((i.totalhp/16).floor,true)
       end
 
-      if i.crested == :MEGANIUM && KAIZOMOD 
+      if i.crested == :MEGANIUM && KAIZOMOD
         party=@battle.pbParty(i.index)
         for j in 0...party.length
           next if @battle.battlers.include?(j)
@@ -6421,7 +6421,7 @@ class PokeBattle_Battle
       next if sides[i].effects[:LuckyWind] == 0
 
       sides[i].effects[:LuckyWind] -= 1
-      pbDisplay(_INTL("#{texts[i]} team's Lucky Wind ran out!")) if sides[i].effects[:LuckyWind] == 0
+      pbDisplay(_INTL("#{texts[i]} team's Lucky Wind stopped blowing!")) if sides[i].effects[:LuckyWind] == 0
     end
     # EmbargoSide
     for i in 0...2

--- a/Battle_Move.rb
+++ b/Battle_Move.rb
@@ -656,7 +656,7 @@ class PokeBattle_Move
 
     # Gen 9 Mod - Tera Shell makes moves not very effective on full HP
     if opponent.ability == :TERASHELL && opponent.hp == opponent.totalhp
-      if mod1 * mod2 == 0 
+      if mod1 * mod2 == 0
         return 0
       else
         return 2
@@ -803,7 +803,7 @@ class PokeBattle_Move
 
     # Gen 9 Mod - Tera Shell makes moves not very effective on full HP
     if opponent.ability == :TERASHELL && opponent.hp == opponent.totalhp
-      if mod1 * mod2 == 0 
+      if mod1 * mod2 == 0
         return 0
       else
         return 2
@@ -1432,7 +1432,7 @@ class PokeBattle_Move
     if attacker.hasWorkingItem(:WIDELENS)
       accuracy *= 1.1
     end
-    if attacker.pbOwnSide.effects[:LuckyWind] != 0
+    if attacker.pbOwnSide.effects[:LuckyWind] > 0
       accuracy *= 1.15
     end
     # Hypno Crest, Stantler Crest
@@ -1481,7 +1481,7 @@ class PokeBattle_Move
   def pbCritRate?(attacker, opponent)
     return -1 if self.is_a?(PokeBattle_Confusion)
     return -1 if (opponent.ability == :BATTLEARMOR || opponent.ability == :SHELLARMOR) && !opponent.moldbroken
-    return -1 if opponent.pbOwnSide.effects[:LuckyChant] > 0
+    return -1 if opponent.pbOwnSide.effects[:LuckyChant] > 0 || (KAIZOMOD && opponent.pbOwnSide.effects[:LuckyWind] > 0)
     return 3 if attacker.effects[:LaserFocus] > 0 || @function == 0xA0 || @function == 0x319 || @function == 0x90B # Frost Breath, Surging Strikes, # Gen 9 Mod - Added Flower Trick
     return 3 if @function == 0x201 && attacker.hp <= ((attacker.totalhp) * 0.5).floor # Gale Strike
     return 3 if attacker.ability == :MERCILESS && (opponent.status == :POISON || @battle.FE == :CORROSIVEMIST || ([:CORROSIVE, :WASTELAND, :MURKWATERSURFACE].include?(@battle.FE) && !attacker.isAirborne?))
@@ -1494,7 +1494,7 @@ class PokeBattle_Move
     c += 1 if !@data.nil? && highCritRate?
     c += 1 if attacker.inHyperMode? && getMoveType(@move) == :SHADOW
     c += 1 if attacker.ability == :SUPERLUCK
-    c += 1 if attacker.pbOwnSide.effects[:LuckyWind] != 0
+    c += 1 if attacker.pbOwnSide.effects[:LuckyWind] > 0
     c += 2 if attacker.hasWorkingItem(:STICK) && (attacker.pokemon.species == :FARFETCHD || attacker.pokemon.species == :SIRFETCHD)
     c += 2 if attacker.hasWorkingItem(:LUCKYPUNCH) && (attacker.pokemon.species == :CHANSEY)
     if @battle.FE == :MIRROR
@@ -2351,7 +2351,7 @@ class PokeBattle_Move
         damage*=1.5 if @battle.weather == :RAINDANCE && !opponent.hasWorkingItem(:UTILITYUMBRELLA)
         damage*=0.5 if @battle.pbWeather == :SUNNYDAY && !@move == :HYDROSTEAM && !@move == :SPARKLINGARIA && !attacker.hasWorkingItem(:UTILITYUMBRELLA)
         damage*=2 if attacker.ability == :WATERBUBBLE
-      when :ICE 
+      when :ICE
         damage*=1.5 if @battle.weather == :HAIL && attacker.crested == :VANILLUXE && !opponent.hasWorkingItem(:UTILITYUMBRELLA)
     end
     # Critical hits
@@ -2526,7 +2526,7 @@ class PokeBattle_Move
     end
     ruinmult = (@battle.FE == :FROZENDIMENSION || @battle.FE == :DIMENSONAL) && !KAIZOMOD ? 0.67 : 0.75
     # Gen 9 Mod - Added Ruinous Abilities (This is scuffed imo) --> prolly should do it in finalmult instead
-    if (attacker.pbOpposing1.ability == :VESSELOFRUIN || attacker.pbOpposing2.ability == :VESSELOFRUIN || attacker.pbPartner.ability == :VESSELOFRUIN) && attacker.ability != :VESSELOFRUIN && pbIsSpecial?(type) 
+    if (attacker.pbOpposing1.ability == :VESSELOFRUIN || attacker.pbOpposing2.ability == :VESSELOFRUIN || attacker.pbPartner.ability == :VESSELOFRUIN) && attacker.ability != :VESSELOFRUIN && pbIsSpecial?(type)
       atkmult *= ruinmult
     end
     if (attacker.pbOpposing1.ability == :TABLETSOFRUIN || attacker.pbOpposing2.ability == :TABLETSOFRUIN || attacker.pbPartner.ability == :TABLETSOFRUIN) && attacker.ability != :TABLETSOFRUIN && pbIsPhysical?(type)
@@ -2539,7 +2539,7 @@ class PokeBattle_Move
         defmult *= ruinmult
       end
     end
-    if ((opponent.pbOpposing1.ability == :BEADSOFRUIN || opponent.pbOpposing2.ability == :BEADSOFRUIN || opponent.pbPartner.ability == :BEADSOFRUIN) && opponent.ability != :BEADSOFRUIN) 
+    if ((opponent.pbOpposing1.ability == :BEADSOFRUIN || opponent.pbOpposing2.ability == :BEADSOFRUIN || opponent.pbPartner.ability == :BEADSOFRUIN) && opponent.ability != :BEADSOFRUIN)
       if @battle.state.effects[:WonderRoom] != 0 && pbIsPhysical?(type)
         defmult *= ruinmult
       elsif @battle.state.effects[:WonderRoom] == 0 && pbIsSpecial?(type)
@@ -2747,7 +2747,7 @@ class PokeBattle_Move
     pri += 3 if attacker.ability == :TRIAGE && (PBStuff::HEALFUNCTIONS).include?(@function)
     pri -= 1 if @battle.FE == :DEEPEARTH && @move == :COREENFORCER
     pri -= 2 if attacker.ability == :MYCELIUMMIGHT && @basedamage==0 && attacker.effects[:TwoTurnAttack] == 0 # Is status move # Gen 9 Mod - Added Mycelium Might
-    
+
     # Giga updates here
     # pri -= 6 if attacker.species == :CORVIKNIGHT && attacker.giga && @move == :BRAVEBIRD
 

--- a/Battler.rb
+++ b/Battler.rb
@@ -933,6 +933,9 @@ class PokeBattle_Battler
     if self.pbOwnSide.effects[:Tailwind] > 0
       speed = speed * 2
     end
+    if KAIZOMOD && self.pbOwnSide.effects[:LuckyWind] > 0
+      speed = speed * 2
+    end
    case self.ability
       when :SWIFTSWIM
         speed *= 2 if @battle.pbWeather == :RAINDANCE || @battle.FE == :UNDERWATER || ([:WATERSURFACE, :MURKWATERSURFACE].include?(@battle.FE) && !self.isAirborne?)
@@ -2463,7 +2466,7 @@ class PokeBattle_Battler
         end
       end
 
-      if !@battle.pbCheckGlobalAbility(:DELTASTREAM) && !@battle.pbCheckGlobalAbility(:TEMPEST) && ![:Winds,:BlowingLeaves,:SwirlingLeaves].include?($game_screen.weather_type) && !((self.pbOwnSide.effects[:Tailwind]>0 || self.pbOpposingSide.effects[:Tailwind]>0) && [:MOUNTAIN,:SNOWYMOUNTAIN,:VOLCANICTOP,:SKY].include?(@battle.FE))
+      if !@battle.pbCheckGlobalAbility(:DELTASTREAM) && !@battle.pbCheckGlobalAbility(:TEMPEST) && ![:Winds,:BlowingLeaves,:SwirlingLeaves].include?($game_screen.weather_type) && !((self.pbOwnSide.effects[:Tailwind]>0 || self.pbOpposingSide.effects[:Tailwind]>0 || (KAIZOMOD && (self.pbOwnSide.effects[:LuckyWind] > 0 || self.pbOpposingSide.effects[:LuckyWind] > 0))) && [:MOUNTAIN,:SNOWYMOUNTAIN,:VOLCANICTOP,:SKY].include?(@battle.FE))
         if @battle.weather == :STRONGWINDS && !@battle.keepPrimalWeather
           @battle.pbDisplay(_INTL("The mysterious air current has dissipated!"))
           unless ((self.ability == :PRIMORDIALSEA) || (self.ability == :DESOLATELAND) || (self.ability == :DELTASTREAM)) && onactive
@@ -2604,7 +2607,7 @@ class PokeBattle_Battler
     end
 
     # Gen 9 Mod - Added Wind Rider
-    if self.ability == (:WINDRIDER) && onactive && pbOwnSide.effects[:Tailwind] > 0
+    if self.ability == (:WINDRIDER) && onactive && (pbOwnSide.effects[:Tailwind] > 0 || (KAIZOMOD && pbOwnSide.effects[:LuckyWind] > 0))
       self.pbIncreaseStatBasic(PBStats::ATTACK, 1)
       @battle.pbCommonAnimation("StatUp", self, nil)
       @battle.pbDisplay(_INTL("{1}'s Wind Rider raised its Attack!", pbThis))
@@ -3423,11 +3426,10 @@ class PokeBattle_Battler
       inc = 4
       inc = 6 if (@battle.FE == :MOUNTAIN || @battle.FE == :SNOWYMOUNTAIN || @battle.FE == :VOLCANICTOP || @battle.FE == :CLOUDS)
       inc = 8 if @battle.FE == :SKY
-      self.pbOwnSide.effects[:Tailwind]+=inc
-      self.pbOwnSide.effects[:LuckyWind]+=inc
-      self.pbOwnSide.effects[:LuckyChant]+=inc
-      @battle.pbDisplay(_INTL("{1}'s {2} brought in a Lucky Wind for its team!",self.pbThis,getAbilityName(self.ability)))
 
+      # if there is an existing Lucky Wind, the counter is set to whichever is longer
+      self.pbOwnSide.effects[:LuckyWind]=inc if inc > self.pbOwnSide.effects[:LuckyWind]
+      @battle.pbDisplay(_INTL("{1}'s {2} brought in a Lucky Wind for its team!",self.pbThis,getAbilityName(self.ability)))
       if (@battle.FE == :MOUNTAIN || @battle.FE == :SNOWYMOUNTAIN || @battle.FE == :VOLCANICTOP || @battle.FE == :SKY) && !@battle.state.effects[:HeavyRain] && !@battle.state.effects[:HarshSunlight]
         @battle.weather=:STRONGWINDS
         @battle.weatherduration=6
@@ -3452,7 +3454,7 @@ class PokeBattle_Battler
     # needs to be checked before mummy/wandering spirit stench is check before ability change
     if target.damagestate.calcdamage > 0 && !target.damagestate.substitute
       # Gen 9 Mod - Added Covert Cloak
-      if (target.ability != :SHIELDDUST || target.moldbroken) && !target.hasWorkingItem(:COVERTCLOAK) && target.pbOwnSide.effects[:LuckyWind] != 0 &&
+      if (target.ability != :SHIELDDUST || target.moldbroken) && !target.hasWorkingItem(:COVERTCLOAK) && target.pbOwnSide.effects[:LuckyWind] == 0 &&
         if (user.hasWorkingItem(:KINGSROCK) || user.hasWorkingItem(:RAZORFANG)) && !move.canFlinch?
           if @battle.pbRandom(10) == 0
             target.effects[:Flinch] = true
@@ -5632,7 +5634,7 @@ class PokeBattle_Battler
         basemove.pbAdditionalEffect(user, target)
       end
 
-      if (!basemove.zmove) && target.damagestate.calcdamage > 0 && user.ability != :SHEERFORCE && target.pbOwnSide.effects[:LuckyWind] != 0 &&
+      if (!basemove.zmove) && target.damagestate.calcdamage > 0 && user.ability != :SHEERFORCE && target.pbOwnSide.effects[:LuckyWind] == 0 &&
          ((target.ability != :SHIELDDUST || target.moldbroken && !target.hasWorkingItem(:COVERTCLOAK)) ||
          [0x1C, 0x1D, 0x1E, 0x1F, 0x20, 0x2D, 0x2F, 0x147, 0x186, 0x307, 0x103, 0x105, 0x204, 0x900].include?(basemove.function)) # Selfbuffing additional effects
         addleffect = basemove.effect
@@ -5642,7 +5644,7 @@ class PokeBattle_Battler
           addleffect = 20 if basemove.move == :FREEZEDRY
         end
         addleffect = 20 if basemove.move == :OMINOUSWIND && @battle.FE == :HAUNTED
-        addleffect *= 2 if user.ability == :SERENEGRACE || @battle.FE == :RAINBOW || user.pbOwnSide.effects[:LuckyWind] != 0
+        addleffect *= 2 if user.ability == :SERENEGRACE || @battle.FE == :RAINBOW || user.pbOwnSide.effects[:LuckyWind] > 0
         addleffect = 100 if $DEBUG && Input.press?(Input::CTRL) && !@battle.isOnline?
         addleffect = 100 if basemove.move == :MIRRORSHOT && @battle.FE == :MIRROR
         addleffect = 100 if basemove.move == :STRANGESTEAM && @battle.FE == :FAIRYTALE

--- a/DevLog.md
+++ b/DevLog.md
@@ -55,8 +55,6 @@
     - Lucky Wind
       - needs testing
       - double-check Angie fight with Lucky Wind
-      - should be a "synchronous effect" with Tailwind and Lucky Chant
-      - should NOT be able to "stack" with Tailwind and Lucky Chant
 
   ## Rebalancing
     -
@@ -142,7 +140,7 @@
       - Hydreigon
       - Vanilluxe
       - Spinda
-  
+
     ## Other
     - Utility Umbrella Changes
 
@@ -150,6 +148,17 @@
     - Learnset updates for new moves
 
 # Journal
+
+- 5/5 (@Ren)
+  - Updated Lucky Wind to be separate from Tailwind and Lucky Chant (they can stack)
+  - Updated Inspection to display Lucky Wind
+  - Fixed Lucky Wind to prevent additional effects (previously additional effects were only possible if the opponent had Lucky Wind up)
+  - Added ability description for Lucky Wind
+
+- 4/19 (@Ren)
+  - Updated Pressure to lower opponents' special attack on entry
+    - In Dimensional fields, it additionally lowers opponents' special attack
+    - Updated AI for Pressure accordingly
 
 - 4/14/25 (SWu)
   - TODO: refactor Battler.rb more (search for: "Kaizomod Refactor")
@@ -159,11 +168,6 @@
   - move relearner can learn level 0 moves (clean up montext)
   - Utility Umbrella rework -- now only protects against the NEGATIVE impacts of sun and rain
     - double check interactions here with Desolate Land and Primordial Sea
-
-- 4/19 (@Ren)
-  - Updated Pressure to lower opponents' special attack on entry
-    - In Dimensional fields, it additionally lowers opponents' special attack
-    - Updated AI for Pressure accordingly
 
 - 4/10 (@Ren)
   - Implemented Pressure changes

--- a/Rejuv/Battle_Inspect.rb
+++ b/Rejuv/Battle_Inspect.rb
@@ -39,7 +39,7 @@ PokeBattle_Battler.class_eval {
     atk = (atk * atkmult * 1.0 / 0x1000).round
     return atk
   end
-  
+
   def pbCalcSpAtk()
     atk = @spatk
     atkstage = @stages[PBStats::SPATK] + 6
@@ -72,11 +72,11 @@ PokeBattle_Battler.class_eval {
     atkmult = (atkmult * 1.3).round if self.ability == :PROTOSYNTHESIS && self.effects[:Protosynthesis][0] == PBStats::SPATK # Gen 9 Mod - Added Protosynthesis
     atkmult = (atkmult * 0.75).round if @battle.pbCheckGlobalAbility(:TABLETSOFRUIN) && !self.ability == :TABLETSOFRUIN # Gen 9 Mod - Added Tablets of Ruin
     # Gen 9 Mod - Added Hadron Engine
-    atkmult = (atkmult * (5461 / 4096.to_f)).round if self.ability == :HADRONENGINE && (@battle.FE == :ELECTERRAIN || @battle.state.effects[:ELECTERRAIN] > 0) &&  @battle.FE != :FROZENDIMENSION            
+    atkmult = (atkmult * (5461 / 4096.to_f)).round if self.ability == :HADRONENGINE && (@battle.FE == :ELECTERRAIN || @battle.state.effects[:ELECTERRAIN] > 0) &&  @battle.FE != :FROZENDIMENSION
     atk = (atk * atkmult * 1.0 / 0x1000).round
     return atk
-  end  
-  
+  end
+
   def pbCalcDefense()
     defense = @defense
     defstage = @stages[PBStats::DEFENSE] + 6
@@ -106,10 +106,10 @@ PokeBattle_Battler.class_eval {
     defmult = (defmult * 1.3).round if self.ability == :PROTOSYNTHESIS && self.effects[:Protosynthesis][0] == PBStats::DEFENSE # Gen 9 Mod - Added Protosynthesis
     defmult = (defmult * 0.75).round if @battle.pbCheckGlobalAbility(:SWORDOFRUIN) && self.ability != :SWORDOFRUIN # Gen 9 Mod - Added Sword of Ruin
     defmult = (defmult * 0.75).round if @battle.pbCheckGlobalAbility(:BEADSOFRUIN) && self.ability != :BEADSOFRUIN && @battle.state.effects[:WonderRoom] != 0 # Gen 9 Mod - Added Beads of Ruin
-    defense = (defense * defmult * 1.0 / 0x1000).round  
+    defense = (defense * defmult * 1.0 / 0x1000).round
     return defense
-  end    
-  
+  end
+
    def pbCalcSpDef()
     defense = @spdef
     defstage = @stages[PBStats::SPDEF] + 6
@@ -145,8 +145,8 @@ PokeBattle_Battler.class_eval {
     defmult = (defmult * 0.75).round if @battle.pbCheckGlobalAbility(:SWORDOFRUIN) && self.ability != :SWORDOFRUIN && @battle.state.effects[:WonderRoom] != 0 # Gen 9 Mod - Added Sword of Ruin
     defense = (defense * defmult * 1.0 / 0x1000).round
     return defense
-  end  
-  
+  end
+
   def pbCalcAcc()
     accstage = self.stages[PBStats::ACCURACY]
     accuracy = accstage >= 0 ? (accstage + 3) * 100 / 3 : 300 / (3 - accstage)
@@ -158,7 +158,7 @@ PokeBattle_Battler.class_eval {
     accuracy *= 0.9 if self.ability == :LONGREACH && [:ROCKY, :FOREST].include?(@battle.FE)
     return accuracy.round
   end
-  
+
   def pbCalcEva()
     evastage = self.stages[PBStats::EVASION]
     evastage = 0 if self.effects[:Foresight] || self.effects[:MiracleEye]
@@ -170,7 +170,7 @@ PokeBattle_Battler.class_eval {
     evasion *= 1.1 if self.hasWorkingItem(:LAXINCENSE)
     return evasion.round
   end
-  
+
   def pbCalcCrit()
     c = 0
     c += self.effects[:FocusEnergy]
@@ -186,9 +186,9 @@ PokeBattle_Battler.class_eval {
 
 def pbShowBattleStats(pkmn)
   friend=@battle.battlers[0]
-  atksbl="+"  
+  atksbl="+"
   atksbl=" " if pkmn.stages[PBStats::ATTACK]<0
-  defsbl="+"  
+  defsbl="+"
   defsbl=" " if pkmn.stages[PBStats::DEFENSE]<0
   spasbl="+"
   spasbl=" " if pkmn.stages[PBStats::SPATK]<0
@@ -207,14 +207,14 @@ def pbShowBattleStats(pkmn)
     crit=12.5
   elsif c==2
     crit=50
-  else 
+  else
     crit=100
-  end 
+  end
   shownmon = pkmn.effects[:Illusion] ? pkmn.effects[:Illusion] : pkmn
-  if (!shownmon.type2.nil?) 
-    report = [_INTL("Type: {1}/{2}",toProperCase(shownmon.type1),toProperCase(shownmon.type2))]  
-  else  
-    report = [_INTL("Type: {1}",toProperCase(shownmon.type1))]  
+  if (!shownmon.type2.nil?)
+    report = [_INTL("Type: {1}/{2}",toProperCase(shownmon.type1),toProperCase(shownmon.type2))]
+  else
+    report = [_INTL("Type: {1}",toProperCase(shownmon.type1))]
   end
   report.push(_INTL("Level: {1}",pkmn.level))
   if @battle.pbOwnedByPlayer?(pkmn.index) || $DEBUG
@@ -324,18 +324,19 @@ def pbShowBattleStats(pkmn)
   dur="Permanent" if @battle.state.effects[:Gravity]<0
   turns="turns"
   turns="" if @battle.state.effects[:Gravity]<0
-  report.push(_INTL("Gravity: {1} {2}",dur,turns)) if @battle.state.effects[:Gravity]!=0  
-  report.push(_INTL("Tailwind: {1} turns",pkmn.pbOwnSide.effects[:Tailwind])) if pkmn.pbOwnSide.effects[:Tailwind]>0   
+  report.push(_INTL("Gravity: {1} {2}",dur,turns)) if @battle.state.effects[:Gravity]!=0
+  report.push(_INTL("Lucky Wind: {1} turns",pkmn.pbOwnSide.effects[:LuckyWind])) if KAIZOMOD && pkmn.pbOwnSide.effects[:LuckyWind]>0
+  report.push(_INTL("Tailwind: {1} turns",pkmn.pbOwnSide.effects[:Tailwind])) if pkmn.pbOwnSide.effects[:Tailwind]>0
   report.push(_INTL("Reflect: {1} turns",pkmn.pbOwnSide.effects[:Reflect])) if pkmn.pbOwnSide.effects[:Reflect]>0
   report.push(_INTL("Light Screen: {1} turns",pkmn.pbOwnSide.effects[:LightScreen])) if pkmn.pbOwnSide.effects[:LightScreen]>0
   report.push(_INTL("Aurora Veil: {1} turns",pkmn.pbOwnSide.effects[:AuroraVeil])) if pkmn.pbOwnSide.effects[:AuroraVeil]>0
   report.push(_INTL("Arenite Wall: {1} turns",pkmn.pbOwnSide.effects[:AreniteWall])) if pkmn.pbOwnSide.effects[:AreniteWall]>0
   report.push(_INTL("Safeguard: {1} turns",pkmn.pbOwnSide.effects[:Safeguard])) if pkmn.pbOwnSide.effects[:Safeguard]>0
   report.push(_INTL("Lucky Chant: {1} turns",pkmn.pbOwnSide.effects[:LuckyChant])) if pkmn.pbOwnSide.effects[:LuckyChant]>0
-  report.push(_INTL("Mist: {1} turns",pkmn.pbOwnSide.effects[:Mist])) if pkmn.pbOwnSide.effects[:Mist]>0 
+  report.push(_INTL("Mist: {1} turns",pkmn.pbOwnSide.effects[:Mist])) if pkmn.pbOwnSide.effects[:Mist]>0
   #report.push(_INTL("Altered Field: {1} turns",@battle.state.effects[:Terrain])) if @battle.state.effects[:Terrain]>0
-  #report.push(_INTL("Messed up Field: {1} turns",@battle.state.effects[:Splintered])) if @battle.state.effects[:Splintered]>0  
-  report.push(_INTL("Electric Terrain: {1} turns",@battle.state.effects[:ELECTERRAIN])) if @battle.state.effects[:ELECTERRAIN]>0  
+  #report.push(_INTL("Messed up Field: {1} turns",@battle.state.effects[:Splintered])) if @battle.state.effects[:Splintered]>0
+  report.push(_INTL("Electric Terrain: {1} turns",@battle.state.effects[:ELECTERRAIN])) if @battle.state.effects[:ELECTERRAIN]>0
   report.push(_INTL("Grassy Terrain: {1} turns",@battle.state.effects[:GRASSY])) if @battle.state.effects[:GRASSY]>0
   report.push(_INTL("Misty Terrain: {1} turns",@battle.state.effects[:MISTY])) if @battle.state.effects[:MISTY]>0
   report.push(_INTL("Psychic Terrain: {1} turns",@battle.state.effects[:PSYTERRAIN])) if @battle.state.effects[:PSYTERRAIN]>0
@@ -361,18 +362,18 @@ def pbShowBattleStats(pkmn)
   report.push(_INTL("Total fainted: {1}",pkmn.pbOwnSide.effects[:LastRespects])) if pkmn.pbOwnSide.effects[:LastRespects] > 0 # Gen 9 Mod - Added Last Respects
   Kernel.pbMessage((_INTL"Inspecting {1}:",pkmn.name),report, report.length)
 end
-#DemICE left the chat>>>>  
+#DemICE left the chat>>>>
 
-#>>>>DemICE entered the chat    
+#>>>>DemICE entered the chat
 def StatInfoTarget(index)
   for i in 0...4
-    if (index&1)==(i&1) && !@battle.battlers[i].isFainted? 
+    if (index&1)==(i&1) && !@battle.battlers[i].isFainted?
       return i
-    end  
+    end
   end
   return -1
-end 
-    
+end
+
 def pbStatInfo(index)
   @sprites["commandwindow"].visible
   curwindow=StatInfoTarget(index)
@@ -403,36 +404,36 @@ def pbStatInfo(index)
           break if !@battle.battlers[curwindow].isFainted?
         end
       elsif Input.trigger?(Input::DOWN)
-        loop do 
+        loop do
           newcurwindow=2 if curwindow==0
           newcurwindow=0 if curwindow==2
           newcurwindow=2 if curwindow==1
           newcurwindow=0 if curwindow==3
           curwindow=newcurwindow
           break if !@battle.battlers[curwindow].isFainted?
-        end  
+        end
       elsif Input.trigger?(Input::LEFT)
-        loop do 
+        loop do
           newcurwindow=3 if curwindow==0
           newcurwindow=0 if curwindow==2
           newcurwindow=2 if curwindow==1
           newcurwindow=1 if curwindow==3
           curwindow=newcurwindow
           break if !@battle.battlers[curwindow].isFainted?
-        end  
+        end
       elsif Input.trigger?(Input::UP)
-        loop do 
+        loop do
           newcurwindow=3 if curwindow==0
           newcurwindow=1 if curwindow==2
           newcurwindow=3 if curwindow==1
           newcurwindow=1 if curwindow==3
           curwindow=newcurwindow
-          break if !@battle.battlers[curwindow].isFainted?                          
+          break if !@battle.battlers[curwindow].isFainted?
         end
       end
     end
   end
-end     
+end
 
 def pbStatInfoF(index)
  # pbShowWindow(FIGHTBOX)
@@ -464,34 +465,34 @@ def pbStatInfoF(index)
           break if !@battle.battlers[curwindow].isFainted?
         end
       elsif Input.trigger?(Input::DOWN)
-        loop do 
+        loop do
           newcurwindow=2 if curwindow==0
           newcurwindow=0 if curwindow==2
           newcurwindow=2 if curwindow==1
           newcurwindow=0 if curwindow==3
           curwindow=newcurwindow
           break if !@battle.battlers[curwindow].isFainted?
-        end  
+        end
       elsif Input.trigger?(Input::LEFT)
-        loop do 
+        loop do
           newcurwindow=3 if curwindow==0
           newcurwindow=0 if curwindow==2
           newcurwindow=2 if curwindow==1
           newcurwindow=1 if curwindow==3
           curwindow=newcurwindow
           break if !@battle.battlers[curwindow].isFainted?
-        end  
+        end
       elsif Input.trigger?(Input::UP)
-        loop do 
+        loop do
           newcurwindow=3 if curwindow==0
           newcurwindow=1 if curwindow==2
           newcurwindow=3 if curwindow==1
           newcurwindow=1 if curwindow==3
           curwindow=newcurwindow
-          break if !@battle.battlers[curwindow].isFainted?                          
+          break if !@battle.battlers[curwindow].isFainted?
         end
       end
     end
   end
-end   
-#DemICE left the chat>>>> 
+end
+#DemICE left the chat>>>>

--- a/Rejuv/Battle_Rejuv.rb
+++ b/Rejuv/Battle_Rejuv.rb
@@ -1,4 +1,4 @@
- class PokeBattle_Battle 
+ class PokeBattle_Battle
   attr_accessor :zettacounter
   attr_accessor :snapshot
 
@@ -72,13 +72,13 @@
     when :PROBOPASS
       @battlers[index].effects[:MagnetRise]=8
       pbAnimation(:MAGNETRISE,@battlers[index],nil) # Magnet Rise animation
-    when :PHIONE 
+    when :PHIONE
       @battlers[index].effects[:AquaRing]=true
       pbAnimation(:AQUARING,@battlers[index],nil) # Aqua Ring animation
     when :VESPIQUEN
       @battlers[index].effects[:VespiCrest] = true
-      @battlers[index].pbIncreaseStatBasic(PBStats::ATTACK,1)  
-      @battlers[index].pbIncreaseStatBasic(PBStats::SPATK,1)  
+      @battlers[index].pbIncreaseStatBasic(PBStats::ATTACK,1)
+      @battlers[index].pbIncreaseStatBasic(PBStats::SPATK,1)
     when :ZANGOOSE
       if @battlers[index].status!=:POISON
         @battlers[index].status=:POISON
@@ -97,7 +97,7 @@
       if sigmove.basedamage == 0
         @battlers[index].pbUseMoveSimple(sigmove.move, -1, -1)
       end
-    end    
+    end
   end
 
   def pbCrestEntry(index,pokemon)
@@ -123,7 +123,7 @@
         @battlers[index].type1 = :FIGHTING
       end
     end
-  
+
   end
 
   def pbCanRun?(idxPokemon)
@@ -184,7 +184,7 @@
         trainereffect = trainer.trainereffect[pkmn.pbFaintedPokemonCount]
         if trainer.trainereffect[:buffactivation] == :Limited
           return if trainer.trainereffectused.include?(pkmn.pbFaintedPokemonCount)
-          trainer.trainereffectused.push(pkmn.pbFaintedPokemonCount)      
+          trainer.trainereffectused.push(pkmn.pbFaintedPokemonCount)
         end
       end
     else
@@ -353,11 +353,6 @@
       trainer.trainerdelaycounter = (trainereffect[:delayedaction][:delay])
     end
     if trainereffect[:changeAbility]
-      if (pkmn.ability == :LUCKYWIND)
-        pbAnimation(:TAILWIND,anim,nil)
-        pkmn.pbOwnSide.effects[:Tailwind]+=4
-        @battle.pbDisplay(_INTL("{1}'s {2} brought in a Tailwind for its team!",pkmn.pbThis,getAbilityName(pkmn.ability)))
-      end
       pkmn.ability = trainereffect[:changeAbility][0]
       animation = trainereffect[:changeAbility][1]
       message = trainereffect[:changeAbility][2]

--- a/Rejuv/abiltext.rb
+++ b/Rejuv/abiltext.rb
@@ -2158,4 +2158,10 @@ ABILHASH = {
     :desc => "Uses Rage Powder on entry."
 },
 
+:LUCKYWIND => {
+    :ID => 391,
+    :name => "Lucky Wind",
+    :desc => "Summons a Lucky Wind that boosts allies' Speed, Accuracy, and likelihood of added effects and critical hits while preventing opponents' critical hits and added effects.",
+    :fullDesc => "Summons a Lucky Wind on entry that buffs allies for four turns, doubling their Speed and likelihood of added effects, boosting their accuracy by 15%, and boosting their critical-hit ratios by 1 stage, while protecting them from the opponents' critical hits and added effects."
+}
 }


### PR DESCRIPTION
- Lucky Wind creates a separate effect from Tailwind and Lucky Chant, and they can be stacked.
- Fixed bug that only allowed side effects to occur if Lucky Wind was set up by the opponent
- Added Lucky Wind to inspection
- Added ability description for Lucky Wind